### PR TITLE
Apply Material Design 3 to chatbot widget

### DIFF
--- a/chatbot-widget/package.json
+++ b/chatbot-widget/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "@mui/material": "^7.1.1",
+    "@mui/icons-material": "^7.1.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.6",

--- a/chatbot-widget/src/Chatbot.css
+++ b/chatbot-widget/src/Chatbot.css
@@ -106,14 +106,9 @@
 }
 
 .chatbot-input {
-  border-top: 1px solid #ddd;
   padding: 12px;
   width: 100%;
   box-sizing: border-box;
-  border: none;
-  font-size: 14px;
-  outline: none;
-  background-color: white;
   border-radius: 0 0 10px 10px;
 }
 

--- a/chatbot-widget/src/Chatbot.tsx
+++ b/chatbot-widget/src/Chatbot.tsx
@@ -3,6 +3,21 @@ import { Provider } from 'react-redux';
 import { store } from './store';
 import ChatbotUI from './ChatbotUI';
 import './Chatbot.css';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { experimental_extendTheme as extendTheme } from '@mui/material/styles';
+
+const theme = extendTheme({
+  cssVarPrefix: 'md3',
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: { main: '#6750A4' },
+        secondary: { main: '#625B71' },
+      },
+    },
+  },
+  typography: { fontFamily: 'Roboto, Arial, sans-serif' },
+});
 
 type ChatbotProps = {
   apiUrl: string;
@@ -10,12 +25,14 @@ type ChatbotProps = {
 };
 
 export default function Chatbot({ apiUrl, avatarUrl }: ChatbotProps) {
-  // Imposta dinamicamente la base URL nel contesto globale (accessibile da rasaApi)
   (window as any).__CHATBOT_API_URL__ = apiUrl;
 
   return (
     <Provider store={store}>
-      <ChatbotUI avatarUrl={avatarUrl} />
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <ChatbotUI avatarUrl={avatarUrl} />
+      </ThemeProvider>
     </Provider>
   );
 }

--- a/chatbot-widget/src/ChatbotUI.tsx
+++ b/chatbot-widget/src/ChatbotUI.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { Box, Paper, Typography, IconButton, Avatar, TextField, Button } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
 import { rasaApi } from './services/rasaApi';
 
 type Message = {
@@ -67,72 +69,78 @@ export default function ChatbotUI({ avatarUrl }: ChatbotUIProps) {
     <>
       {!isOpen && (
         <>
-          <button
+          <IconButton
             className="chatbot-float"
             onClick={() => {
               setIsOpen(true);
               setShowPreview(false);
             }}
+            color="primary"
+            size="large"
           >
-            <img src={defaultAvatar} alt="Apri Chatbot" />
-          </button>
+            <Avatar src={defaultAvatar} alt="Apri Chatbot" />
+          </IconButton>
 
           {showPreview && (
-            <div className="chatbot-preview-bubble">
+            <Paper className="chatbot-preview-bubble" elevation={3}>
               {messages[0].text}
-            </div>
+            </Paper>
           )}
         </>
       )}
 
       {isOpen && (
-        <div className="chatbot-wrapper">
-          <div className="chatbot-head">
-            <div className="chatbot-head-left">
-              <img
-                src={defaultAvatar}
-                alt="Avatar"
-                className="chatbot-avatar"
-              />
-              <span>Chatbot Biblioteca</span>
-            </div>
-            <span className="chatbot-toggle" onClick={() => setIsOpen(false)}>
-              ×
-            </span>
-          </div>
+        <Paper className="chatbot-wrapper" elevation={4}>
+          <Box className="chatbot-head">
+            <Box className="chatbot-head-left">
+              <Avatar src={defaultAvatar} className="chatbot-avatar" />
+              <Typography variant="subtitle1">Chatbot Biblioteca</Typography>
+            </Box>
+            <IconButton
+              size="small"
+              className="chatbot-toggle"
+              onClick={() => setIsOpen(false)}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
 
-          <div className="chatbot-box">
+          <Box className="chatbot-box">
             {messages.map((msg, i) => (
-              <div key={i} className={`chatbot-message ${msg.from}`}>
-                <div className={`chatbot-bubble ${msg.from}`}>
+              <Box key={i} className={`chatbot-message ${msg.from}`}>
+                <Paper className={`chatbot-bubble ${msg.from}`} sx={{ p: 1 }}>
                   {msg.text}
-                </div>
+                </Paper>
                 {msg.buttons && (
-                  <div className="chatbot-buttons">
+                  <Box className="chatbot-buttons">
                     {msg.buttons.map((btn, idx) => (
-                      <button
+                      <Button
                         key={idx}
                         onClick={() => handleSend(btn.title, btn.payload)}
+                        variant="outlined"
+                        size="small"
                         className="chatbot-button"
                       >
                         {btn.title}
-                      </button>
+                      </Button>
                     ))}
-                  </div>
+                  </Box>
                 )}
-              </div>
+              </Box>
             ))}
             <div ref={messagesEndRef} />
-          </div>
+          </Box>
 
-          <input
+          <TextField
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleSend(input)}
             placeholder="Scrivi il tuo messaggio..."
             className="chatbot-input"
+            fullWidth
+            variant="outlined"
           />
-        </div>
+        </Paper>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- add Material UI dependencies to the widget
- wrap chatbot with `ThemeProvider`
- update component to use Material UI components
- simplify input CSS styles

## Testing
- `npm --prefix chatbot-widget run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npm --prefix frontend run build` *(fails: various missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68417116a4708323be824b15fbbe263e