### PR TITLE
Add real library home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from 'react-router-dom';
 import { Chatbot } from 'chatbot-widget';
-import Navbar from "./components/Navbar";
-import Home from "./components/Home";
-import PrestitoForm from "./components/PrestitoForm";
-import LibriInGiro from "./LibriInGiro";
+import Navbar from './components/Navbar';
+import Home from './components/Home';
+import PrestitoForm from './components/PrestitoForm';
+import LibriInGiro from './LibriInGiro';
+import AdminLogin from './components/AdminLogin';
+import ProtectedRoute from './context/ProtectedRoute';
 import 'chatbot-widget/dist/Chatbot.css';
 
 function App() {
@@ -12,8 +14,23 @@ function App() {
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/libri-in-giro" element={<LibriInGiro />} />
-        <Route path="/registra-prestito" element={<PrestitoForm />} />
+        <Route path="/login" element={<AdminLogin />} />
+        <Route
+          path="/libri-in-giro"
+          element={
+            <ProtectedRoute>
+              <LibriInGiro />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/registra-prestito"
+          element={
+            <ProtectedRoute>
+              <PrestitoForm />
+            </ProtectedRoute>
+          }
+        />
       </Routes>
       {/* Chatbot persistente in tutte le pagine */}
       <Chatbot apiUrl="http://localhost:5005" avatarUrl="/chatbot-avatar.png" />

--- a/frontend/src/components/AdminLogin.tsx
+++ b/frontend/src/components/AdminLogin.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useAdminAuth } from '../context/AdminAuth';
+
+const AdminLogin: React.FC = () => {
+  const { login } = useAdminAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(username, password);
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ maxWidth: 400, m: '2rem auto', p: 2 }}>
+      <Typography variant="h5" textAlign="center" mb={2}>
+        Accesso Amministratore
+      </Typography>
+      <TextField
+        label="Username"
+        fullWidth
+        margin="normal"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <TextField
+        label="Password"
+        type="password"
+        fullWidth
+        margin="normal"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Button variant="contained" type="submit" fullWidth sx={{ mt: 2 }}>
+        Accedi
+      </Button>
+    </Box>
+  );
+};
+
+export default AdminLogin;

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,17 +1,56 @@
 import { Link as RouterLink } from 'react-router-dom';
-import { Button, Container, Typography } from '@mui/material';
+import {
+  Button,
+  Container,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Box,
+} from '@mui/material';
 
 const Home: React.FC = () => (
-  <Container sx={{ py: 4, textAlign: 'center' }}>
-    <Typography variant="h4" gutterBottom>
-      Benvenuto nella Biblioteca Comunale
-    </Typography>
-    <Typography variant="body1" sx={{ mb: 2 }}>
-      Gestisci i tuoi prestiti e consulta i libri disponibili con facilità.
-    </Typography>
-    <Button variant="contained" component={RouterLink} to="/registra-prestito">
-      Inizia ora
-    </Button>
+  <Container sx={{ py: 4 }}>
+    <Box textAlign="center" mb={4}>
+      <Typography variant="h4" gutterBottom>
+        Benvenuto alla Biblioteca Comunale di Codexia
+      </Typography>
+      <Typography variant="body1">
+        Fondata nel 1925, la nostra biblioteca offre oltre 50.000 volumi e un
+        ambiente accogliente dove coltivare la passione per la lettura.
+      </Typography>
+    </Box>
+
+    <Box mb={4}>
+      <Typography variant="h5" gutterBottom>
+        Prossimi eventi
+      </Typography>
+      <List>
+        <ListItem>
+          <ListItemText primary="12 Ottobre - Presentazione del libro 'Viaggio nel Tempo'" />
+        </ListItem>
+        <ListItem>
+          <ListItemText primary="25 Ottobre - Laboratorio di lettura per bambini" />
+        </ListItem>
+        <ListItem>
+          <ListItemText primary="5 Novembre - Incontro con l'autore Giovanni Rossi" />
+        </ListItem>
+      </List>
+    </Box>
+
+    <Box textAlign="center">
+      <Button
+        variant="contained"
+        component={RouterLink}
+        to="/registra-prestito"
+        sx={{ mr: 2 }}
+      >
+        Gestisci prestiti
+      </Button>
+      <Button variant="outlined" href="mailto:info@biblioteca.it">
+        Contattaci
+      </Button>
+    </Box>
   </Container>
 );
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,24 +3,41 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import { useAdminAuth } from '../context/AdminAuth';
 
-const Navbar: React.FC = () => (
-  <AppBar position="sticky" color="primary">
-    <Toolbar>
-      <Typography variant="h6" sx={{ flexGrow: 1 }}>
-        📚 Biblioteca
-      </Typography>
-      <Button color="inherit" component={NavLink} to="/" end>
-        Home
-      </Button>
-      <Button color="inherit" component={NavLink} to="/libri-in-giro">
-        Libri in giro
-      </Button>
-      <Button color="inherit" component={NavLink} to="/registra-prestito">
-        Registra un prestito
-      </Button>
-    </Toolbar>
-  </AppBar>
-);
+const Navbar: React.FC = () => {
+  const { isLoggedIn, logout } = useAdminAuth();
+
+  return (
+    <AppBar position="sticky" color="primary">
+      <Toolbar>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          📚 Biblioteca
+        </Typography>
+        <Button color="inherit" component={NavLink} to="/" end>
+          Home
+        </Button>
+        {isLoggedIn && (
+          <>
+            <Button color="inherit" component={NavLink} to="/libri-in-giro">
+              Libri in giro
+            </Button>
+            <Button color="inherit" component={NavLink} to="/registra-prestito">
+              Registra un prestito
+            </Button>
+            <Button color="inherit" onClick={logout}>
+              Logout
+            </Button>
+          </>
+        )}
+        {!isLoggedIn && (
+          <Button color="inherit" component={NavLink} to="/login">
+            Login
+          </Button>
+        )}
+      </Toolbar>
+    </AppBar>
+  );
+};
 
 export default Navbar;

--- a/frontend/src/context/AdminAuth.tsx
+++ b/frontend/src/context/AdminAuth.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface AdminAuthContextProps {
+  isLoggedIn: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AdminAuthContext = createContext<AdminAuthContextProps | undefined>(undefined);
+
+export const AdminAuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const navigate = useNavigate();
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(
+    localStorage.getItem('isAdmin') === 'true'
+  );
+
+  const login = async (username: string, password: string) => {
+    try {
+      // Chiamata fittizia, sostituisci con la tua API
+      const response = await fetch('/api/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!response.ok) {
+        throw new Error('Credenziali non valide');
+      }
+      localStorage.setItem('isAdmin', 'true');
+      setIsLoggedIn(true);
+      navigate('/');
+    } catch (err) {
+      alert('Login fallito');
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem('isAdmin');
+    setIsLoggedIn(false);
+    navigate('/login');
+  };
+
+  return (
+    <AdminAuthContext.Provider value={{ isLoggedIn, login, logout }}>
+      {children}
+    </AdminAuthContext.Provider>
+  );
+};
+
+export const useAdminAuth = () => {
+  const ctx = useContext(AdminAuthContext);
+  if (!ctx) {
+    throw new Error('useAdminAuth deve essere usato dentro AdminAuthProvider');
+  }
+  return ctx;
+};

--- a/frontend/src/context/ProtectedRoute.tsx
+++ b/frontend/src/context/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAdminAuth } from './AdminAuth';
+
+const ProtectedRoute: React.FC<{ children: React.ReactElement }> = ({ children }) => {
+  const { isLoggedIn } = useAdminAuth();
+  if (!isLoggedIn) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,16 +6,19 @@ import { Provider } from 'react-redux';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import theme from './theme';
 import { store } from '../src/app/store'; // importa il tuo store corretto
+import { AdminAuthProvider } from './context/AdminAuth';
 
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <App />
-        </ThemeProvider>
+        <AdminAuthProvider>
+          <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <App />
+          </ThemeProvider>
+        </AdminAuthProvider>
       </BrowserRouter>
     </Provider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- expand home page with library description
- add upcoming events and a contact button
- implement admin login page and protected routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684930285b18832381513b01e1adbed0